### PR TITLE
Add fix for null $confirmationURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $subscriber->confirmed = false;
 $subscriber->list_id   = $listID;
 $subscriber->save();
 $subscriber->sendOptInEmail($listID);
+// Or you can pass a confirmation URL
+$subscriber->sendOptInEmail($listID, 'https://your-domain.com/thanks-for-signing-up');
 ```
 
 ### Example 2: Returning the latest list

--- a/src/SuT/PMAPI/Client/Helpers/Subscriber.php
+++ b/src/SuT/PMAPI/Client/Helpers/Subscriber.php
@@ -173,10 +173,16 @@ class Subscriber
             throw new SubscriberEmailOptInException ("Subscriber is not subscribed to list '$listId', can not send email optin.");
         }
 
-        $response = $this->request->emailOptIn->post(array(
+        $options = array(
             'subscription_id' => $this->getListSubscriptionId($listId),
-            'redirectionurl' => $confirmationURL
-        ));
+        );
+
+        if(!is_null($confirmationURL))
+        {
+            $options['redirectionurl'] = $confirmationURL;
+        }
+
+        $response = $this->request->emailOptIn->post($options);
 
         if ($response->isError)
         {


### PR DESCRIPTION
Currently if you use the example in the README

`$subscriber->sendOptInEmail($listID);`

You receive an exception:
```
SuT\PMAPI\Client\Helpers\SubscriberEmailOptInException

Invalid arg 'Argument 'redirectionurl' is not a valid HTTP URL' (<path>/vendor/sut/pmapi/src/SuT/PMAPI/Client/Helpers/Subscriber.php:183)

```

This adds a fix for people who want to use the standard thank you page provided by SuT